### PR TITLE
#6 - Fix the horizontal scroll issue on mobile screen

### DIFF
--- a/src/layouts/EpisodePageLayout.astro
+++ b/src/layouts/EpisodePageLayout.astro
@@ -262,18 +262,21 @@ const getFileName = () => {
 
   > p,
   > ul {
+    white-space: pre-wrap;
+
     &:not(:last-child) {
       margin-bottom: 1.5rem;
     }
-  }
 
-  > p {
-    white-space: pre-wrap;
+    a {
+      word-break: break-word;
+    }
   }
 
   ul {
     list-style-type: disc;
     padding-left: 1.5rem;
+    white-space: pre-wrap;
 
     li:not(:last-child) {
       margin-bottom: 0.5rem;


### PR DESCRIPTION
closes #6 

Looks fine on my iOS emulator:

<img width="370" alt="image" src="https://github.com/user-attachments/assets/cc2d525f-7370-441e-8c9d-812408943b91" />
